### PR TITLE
Limit maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <prerequisites>
-        <maven>3.0.4</maven>
-    </prerequisites>
 
     <developers>
         <developer>
@@ -266,6 +263,27 @@
                                     <mainClass>org.dynjs.cli.Main</mainClass>
                                 </transformer>
                             </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.0.0</version>
+                                </requireMavenVersion>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Hello, everyone. Thank you for your interesting product.
I have a small proposal for dynjs.

The dynjs wiki recommends to use Maven3.
https://github.com/dynjs/dynjs/wiki/Setting-up-development-environment
So I think rejecting Maven2 automatically is convenience for user. How do you think?
