### PR TITLE
[DYNJS-58] Assignment of global variables fails when var is predeclared

### DIFF
--- a/src/main/java/org/dynjs/parser/statement/AssignmentOperationStatement.java
+++ b/src/main/java/org/dynjs/parser/statement/AssignmentOperationStatement.java
@@ -17,6 +17,7 @@ package org.dynjs.parser.statement;
 
 import me.qmx.jitescript.CodeBlock;
 import org.antlr.runtime.tree.Tree;
+import org.dynjs.compiler.DynJSCompiler;
 import org.dynjs.parser.ParserException;
 import org.dynjs.parser.Statement;
 import org.dynjs.runtime.RT;
@@ -52,8 +53,11 @@ public class AssignmentOperationStatement extends BaseStatement implements State
             }};
         } else if (lhs instanceof ResolveIdentifierStatement) {
             return new CodeBlock() {{
-                append(lhs.getCodeBlock());
+            	ResolveIdentifierStatement resolveIdentifierStatement = (ResolveIdentifierStatement) lhs;
+            	aload(DynJSCompiler.Arities.THIS);
+            	ldc(resolveIdentifierStatement.getName());
                 append(rhs.getCodeBlock());
+                invokedynamic("dyn:setProp", sig(void.class, Object.class, Object.class, Object.class), RT.BOOTSTRAP, RT.BOOTSTRAP_ARGS);
             }};
         }
         throw new ParserException("not implemented", getPosition());

--- a/src/test/java/org/dynjs/runtime/DynJSTest.java
+++ b/src/test/java/org/dynjs/runtime/DynJSTest.java
@@ -58,8 +58,14 @@ public class DynJSTest {
                 .isNotNull()
                 .isInstanceOf(String.class)
                 .isEqualTo("test");
+
+        dynJS.eval(context, "var x = undefined; x = 1.0;");
+    	assertThat(context.getScope().resolve("x"))
+    			.isNotNull()
+    			.isInstanceOf(Double.class)
+    			.isEqualTo(1.0);
     }
-    
+
     @Test
     public void defineUnInitializedGlobalVariables() {
         dynJS.eval(context, "var x;");


### PR DESCRIPTION
Test fails for code like this `var x = undefined; x = 'test'`.

The problem is due to `ResolveIdentifierStatement` does more than we
need for loading a local variable and cause the unmatch of written
bytecode.

https://jira.codehaus.org/browse/DYNJS-58
