### PR TITLE
[DYNJS-59] Fix bug related to unary operation in for loop.

### DIFF
--- a/src/main/java/org/dynjs/parser/statement/ForStepExprStatement.java
+++ b/src/main/java/org/dynjs/parser/statement/ForStepExprStatement.java
@@ -59,6 +59,9 @@ public class ForStepExprStatement extends BaseStatement implements Statement {
             append(statement.getCodeBlock());
             label(preIncrement);
             append(increment.getCodeBlock());
+            if (increment instanceof AbstractUnaryOperationStatement) {
+            	pop();
+            }
             go_to(statement.getBeginLabel());
             label(statement.getEndLabel());
             labelStack.pop();

--- a/src/main/java/org/dynjs/parser/statement/ForStepVarStatement.java
+++ b/src/main/java/org/dynjs/parser/statement/ForStepVarStatement.java
@@ -57,6 +57,9 @@ public class ForStepVarStatement extends BaseStatement implements Statement {
             append(statement.getCodeBlock());
             label(preIncrement);
             append(increment.getCodeBlock());
+            if (increment instanceof AbstractUnaryOperationStatement) {
+            	pop();
+            }
             go_to(statement.getBeginLabel());
             label(statement.getEndLabel());
             labelStack.pop();

--- a/src/test/java/org/dynjs/runtime/DynJSTest.java
+++ b/src/test/java/org/dynjs/runtime/DynJSTest.java
@@ -59,7 +59,7 @@ public class DynJSTest {
                 .isInstanceOf(String.class)
                 .isEqualTo("test");
     }
-
+    
     @Test
     public void defineUnInitializedGlobalVariables() {
         dynJS.eval(context, "var x;");
@@ -172,7 +172,7 @@ public class DynJSTest {
         check("var x = 0; for (var i =0;i < 10; i+=1){ x+=1;}; var result = x == 10");
         check("var x = 0; var i =0; for (var w = 0;i < 10; i+=1){ x+=1;}; var result = i == 10");
     	check("var x = 0; for (; x < 10; x += 1) { x += 1; }; var result = x == 10");
-    	check("var i = 0; var x = 33; for(; i < 10; i += 1) { x -= 1} var result = x == 23");
+    	check("var i = 0; var x = 33; for(; i < 10; i++) { x -= 1} var result = x == 23");
     }
 
     @Test


### PR DESCRIPTION
The problem is due to in unary operation statement, local var is pushed to stack for consequent operation, we need to remove it from the stack otherwise for loop will throw [exception](https://gist.github.com/3148773).

The [aload(4)](https://github.com/dynjs/dynjs/blob/master/src/main/java/org/dynjs/parser/statement/AbstractUnaryOperationStatement.java#L50) in `AbstractUnaryOperationStatement` seems to be used to load the snapshot variable to the stack for consequent operation, e.g. `var x = 0; x++ == 0`.

Warning: this may not be a clean fix since I think a better fix would be to fix `AbstractUnaryOperationStatement` that it only loads the snapshot variable to the stack when consequent operation is needed. But it doesn't seem to have enough information to decide it.

https://jira.codehaus.org/browse/DYNJS-59
