### PR TITLE
Bitwise AND, OR and XOR in action

### DIFF
--- a/src/main/java/org/dynjs/parser/Executor.java
+++ b/src/main/java/org/dynjs/parser/Executor.java
@@ -18,6 +18,7 @@ package org.dynjs.parser;
 import org.antlr.runtime.tree.Tree;
 import org.dynjs.parser.statement.ArrayLiteralStatement;
 import org.dynjs.parser.statement.AssignmentOperationStatement;
+import org.dynjs.parser.statement.BitwiseOperationStatement;
 import org.dynjs.parser.statement.BlockStatement;
 import org.dynjs.parser.statement.BooleanLiteralStatement;
 import org.dynjs.parser.statement.BreakStatement;
@@ -234,16 +235,20 @@ public class Executor {
         return new LogicalOperationStatement(tree, "land", l, r);
     }
 
-    public Statement defineAndBitOp(final Tree tree, Statement l, Statement r) {
-        throw new ParserException("not implemented yet", tree);
+    public Statement defineAndBitOp(final Tree tree, Statement leftHandStatement, Statement rightHandStatement) {
+        return defineBitwiseOp(tree, "and", leftHandStatement, rightHandStatement);
     }
 
-    public Statement defineOrBitOp(final Tree tree, Statement l, Statement r) {
-        throw new ParserException("not implemented yet", tree);
+    public Statement defineOrBitOp(final Tree tree, Statement leftHandStatement, Statement rightHandStatement) {
+        return defineBitwiseOp(tree, "or", leftHandStatement, rightHandStatement);
     }
 
-    public Statement defineXorBitOp(final Tree tree, Statement l, Statement r) {
-        throw new ParserException("not implemented yet", tree);
+    public Statement defineXorBitOp(final Tree tree, Statement leftHandStatement, Statement rightHandStatement) {
+    	return defineBitwiseOp(tree, "xor", leftHandStatement, rightHandStatement);
+    }
+
+    public Statement defineBitwiseOp(final Tree tree, String operation, Statement leftHandStatement, Statement rightHandStatement) {
+    	return new BitwiseOperationStatement(tree, operation, leftHandStatement, rightHandStatement);
     }
 
     public Statement defineEqOp(final Tree tree, final Statement l, final Statement r) {

--- a/src/main/java/org/dynjs/parser/statement/BitwiseOperationStatement.java
+++ b/src/main/java/org/dynjs/parser/statement/BitwiseOperationStatement.java
@@ -1,0 +1,37 @@
+package org.dynjs.parser.statement;
+
+import me.qmx.jitescript.CodeBlock;
+
+import org.antlr.runtime.tree.Tree;
+import org.dynjs.compiler.DynJSCompiler;
+import org.dynjs.parser.Statement;
+import org.dynjs.runtime.RT;
+
+public class BitwiseOperationStatement extends BaseStatement implements
+		Statement {
+
+	private final Statement leftHandStatement;
+	private final Statement rightHandStatement;
+	private final String operation;
+
+	public BitwiseOperationStatement(Tree tree, String operation,
+			Statement leftHandStatement, Statement rightHandStatement) {
+		super(tree);
+		this.operation = operation;
+		this.leftHandStatement = leftHandStatement;
+		this.rightHandStatement = rightHandStatement;
+	}
+
+	@Override
+	public CodeBlock getCodeBlock() {
+		return new CodeBlock() {
+			{
+				append(leftHandStatement.getCodeBlock());
+				append(rightHandStatement.getCodeBlock());
+				invokedynamic(operation, DynJSCompiler.Signatures.ARITY_2,
+						RT.BOOTSTRAP, RT.BOOTSTRAP_ARGS);
+			}
+		};
+	}
+
+}

--- a/src/main/java/org/dynjs/runtime/extensions/NumberOperations.java
+++ b/src/main/java/org/dynjs/runtime/extensions/NumberOperations.java
@@ -40,6 +40,18 @@ public class NumberOperations {
         return a % b;
     }
 
+    public static Double and(Double a, Double b) {
+    	return (double) (a.intValue() & b.intValue());
+    }
+
+    public static Double or(Double a, Double b) {
+    	return (double) (a.intValue() | b.intValue());
+    }
+
+    public static Double xor(Double a, Double b) {
+    	return (double) (a.intValue() ^ b.intValue());
+    }
+
     public static Boolean eq(Double a, Double b) {
         if (a.isNaN() || b.isNaN()) {
             return false;

--- a/src/test/java/org/dynjs/runtime/DynJSTest.java
+++ b/src/test/java/org/dynjs/runtime/DynJSTest.java
@@ -150,6 +150,13 @@ public class DynJSTest extends AbstractDynJSTestSupport {
     }
 
     @Test
+    public void testBitwise() {
+    	check("var result = 0x000F & 0x2222", 2.0);
+    	check("var result = 0x000F | 0x2222", 8751.0);
+    	check("var result = 0x000F ^ 0x2222", 8749.0);
+    }
+
+    @Test
     public void testAssignments() {
         check("var x = 1;x += 1; var result = x == 2;");
         check("var x = 1;x -= 1; var result = x == 0;");


### PR DESCRIPTION
- make hex conversion work
- bitwise AND, OR and XOR

https://jira.codehaus.org/browse/DYNJS-69
https://jira.codehaus.org/browse/DYNJS-70
https://jira.codehaus.org/browse/DYNJS-71

Potential improvement:
- for hex number, we could use Integer instead of Double, we have some boxing and unboxing in this implementation
- use Byecode for AND, OR and XOR
