### PR TITLE
Try to generate the exe in a more portable manner.

### DIFF
--- a/src/main/assembly/genexe.sh
+++ b/src/main/assembly/genexe.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "Creating dynjs executable"
-(echo '#!/usr/bin/env java -jar'; cat target/dynjs-all.jar) > dynjs && chmod +x dynjs
+(echo '#!/bin/sh\nexec java -jar $0 "$@"\n'; cat target/dynjs-all.jar) > dynjs && chmod +x dynjs


### PR DESCRIPTION
/bin/sh on linux will pass the command and args as the command to
/usr/bin/env on the shebang line, so we use exec instead and exploit
the 'loophole' with zip files that allows garbage at the head of the
zip.
