### PR TITLE
Fix generated dynjs.sh script to work on Fedora

### DIFF
--- a/src/main/assembly/genexe.sh
+++ b/src/main/assembly/genexe.sh
@@ -4,4 +4,4 @@ if [ ! -d "bin" ]
 then
   mkdir -v "bin"
 fi
-(echo '#!/bin/sh\nexec java -jar $0 "$@"\n'; cat target/dynjs-all.jar) > bin/dynjs && chmod +x bin/dynjs
+(echo -e '#!/bin/sh\nexec java -jar $0 "$@"\n'; cat target/dynjs-all.jar) > bin/dynjs && chmod +x bin/dynjs


### PR DESCRIPTION
-e is required to properly resolve escape characters (\n) on Fedora 18.
