### PR TITLE
Coerce DynArrays to Java arrays in method invocations (DYNJS-118)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.rephract>1.x.incremental.48</version.rephract>
+        <version.rephract>1.x.incremental.55</version.rephract>
         <version.jitescript>0.3.0</version.jitescript>
         <version.aesh>0.38</version.aesh>
         <version.invokebinder>1.2</version.invokebinder>

--- a/src/main/java/org/dynjs/runtime/linker/DynArrayCoercer.java
+++ b/src/main/java/org/dynjs/runtime/linker/DynArrayCoercer.java
@@ -1,0 +1,17 @@
+package org.dynjs.runtime.linker;
+
+import org.dynjs.runtime.DynArray;
+import org.projectodd.rephract.mop.java.ArrayCoercer;
+
+public class DynArrayCoercer extends ArrayCoercer {
+    @Override
+    public Object[] convertToObjectArray(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        Object[] converted = new Object[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = dynArray.get(i);
+        }
+        return converted;
+    }
+}

--- a/src/test/java/org/dynjs/runtime/java/JavaIntegrationTest.java
+++ b/src/test/java/org/dynjs/runtime/java/JavaIntegrationTest.java
@@ -184,7 +184,6 @@ public class JavaIntegrationTest extends AbstractDynJSTestSupport {
     }
 
     @Test
-    @Ignore
     public void testJavaArrayCoercionInMethodCalls() {
         eval("arr = ['foo', 'bar']");
         eval("thing = new org.dynjs.runtime.java.Thing()");


### PR DESCRIPTION
This builds on top of the new array coercion in rephract to coerce
DynArrays to Java arrays as long as all elements of the DynArray can
be coerced to the required Java type.
