### PR TITLE
Fix passing of DynArrays to Java constructors (DYNJS-118)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.rephract>1.x.incremental.55</version.rephract>
+        <version.rephract>1.x.incremental.57</version.rephract>
         <version.jitescript>0.3.0</version.jitescript>
         <version.aesh>0.38</version.aesh>
         <version.invokebinder>1.2</version.invokebinder>

--- a/src/main/java/org/dynjs/runtime/linker/DynArrayCoercer.java
+++ b/src/main/java/org/dynjs/runtime/linker/DynArrayCoercer.java
@@ -2,15 +2,105 @@ package org.dynjs.runtime.linker;
 
 import org.dynjs.runtime.DynArray;
 import org.projectodd.rephract.mop.java.ArrayCoercer;
+import org.projectodd.rephract.mop.java.CoercionMatrix;
 
 public class DynArrayCoercer extends ArrayCoercer {
     @Override
-    public Object[] convertToObjectArray(Object value) {
+    public Object[] coerceToObject(Object value) {
         DynArray dynArray = (DynArray) value;
         int length = (int) dynArray.length();
         Object[] converted = new Object[length];
         for (int i = 0; i < length; i++) {
             converted[i] = dynArray.get(i);
+        }
+        return converted;
+    }
+
+    @Override
+    public boolean[] coerceToBoolean(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        boolean[] converted = new boolean[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = (boolean)dynArray.get(i);
+        }
+        return converted;
+    }
+
+    @Override
+    public byte[] coerceToByte(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        byte[] converted = new byte[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = CoercionMatrix.numberToPrimitiveByte((Number)dynArray.get(i));
+        }
+        return converted;
+    }
+
+    @Override
+    public char[] coerceToChar(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        char[] converted = new char[length];
+        for (int i = 0; i < length; i++) {
+            String string = (String) dynArray.get(i);
+            converted[i] = CoercionMatrix.stringToPrimitiveCharacter((String)dynArray.get(i));
+        }
+        return converted;
+    }
+
+    @Override
+    public double[] coerceToDouble(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        double[] converted = new double[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = CoercionMatrix.numberToPrimitiveDouble((Number)dynArray.get(i));
+        }
+        return converted;
+    }
+
+    @Override
+    public float[] coerceToFloat(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        float[] converted = new float[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = CoercionMatrix.numberToPrimitiveFloat((Number)dynArray.get(i));
+        }
+        return converted;
+    }
+
+    @Override
+    public int[] coerceToInt(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        int[] converted = new int[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = CoercionMatrix.numberToPrimitiveInteger((Number)dynArray.get(i));
+        }
+        return converted;
+    }
+
+    @Override
+    public long[] coerceToLong(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        long[] converted = new long[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = CoercionMatrix.numberToPrimitiveLong((Number)dynArray.get(i));
+        }
+        return converted;
+    }
+
+    @Override
+    public short[] coerceToShort(Object value) {
+        DynArray dynArray = (DynArray) value;
+        int length = (int) dynArray.length();
+        short[] converted = new short[length];
+        for (int i = 0; i < length; i++) {
+            converted[i] = CoercionMatrix.numberToPrimitiveShort((Number)dynArray.get(i));
         }
         return converted;
     }

--- a/src/main/java/org/dynjs/runtime/linker/DynJSCoercionMatrix.java
+++ b/src/main/java/org/dynjs/runtime/linker/DynJSCoercionMatrix.java
@@ -28,7 +28,18 @@ public class DynJSCoercionMatrix extends CoercionMatrix {
         this.manager = manager;
         Lookup lookup = MethodHandles.lookup();
         addCoercion(3, String.class, JSObject.class, lookup.findStatic(DynJSCoercionMatrix.class, "objectToString", methodType(String.class, JSObject.class)));
-        addArrayCoercion(2, DynArray.class, new DynArrayCoercer());
+
+        DynArrayCoercer dynArrayCoercer = new DynArrayCoercer();
+        addArrayCoercion(1, boolean[].class, DynArray.class, dynArrayCoercer);
+        addArrayCoercion(1, byte[].class, DynArray.class, dynArrayCoercer);
+        addArrayCoercion(1, char[].class, DynArray.class, dynArrayCoercer);
+        addArrayCoercion(1, double[].class, DynArray.class, dynArrayCoercer);
+        addArrayCoercion(1, float[].class, DynArray.class, dynArrayCoercer);
+        addArrayCoercion(1, int[].class, DynArray.class, dynArrayCoercer);
+        addArrayCoercion(1, long[].class, DynArray.class, dynArrayCoercer);
+        addArrayCoercion(1, short[].class, DynArray.class, dynArrayCoercer);
+        // Object[] will catch all non-primitive types
+        addArrayCoercion(2, Object[].class, DynArray.class, dynArrayCoercer);
     }
 
     public static String objectToString(JSObject object) {

--- a/src/main/java/org/dynjs/runtime/linker/java/JSJavaImplementationLinkStrategy.java
+++ b/src/main/java/org/dynjs/runtime/linker/java/JSJavaImplementationLinkStrategy.java
@@ -2,6 +2,7 @@ package org.dynjs.runtime.linker.java;
 
 import java.lang.invoke.MethodHandle;
 
+import org.dynjs.runtime.DynArray;
 import org.dynjs.runtime.ExecutionContext;
 import org.dynjs.runtime.JSObject;
 import org.dynjs.runtime.linker.js.ShadowObjectLinkStrategy;
@@ -29,7 +30,9 @@ public class JSJavaImplementationLinkStrategy extends ContextualLinkStrategy<Exe
             return chain.nextStrategy();
         }
 
-        if (args.length == 1 && args[0] instanceof JSObject) {
+        // This is designed to shadow DynObjects as Hashes, but we don't want to
+        // do that for DynArrays. We'll leave that up to the array coercion logic
+        if (args.length == 1 && args[0] instanceof JSObject && !(args[0] instanceof DynArray)) {
 
             binder = binder.spread(JSObject.class)
                     .convert(Object.class, Class.class, ExecutionContext.class, JSObject.class);

--- a/src/test/java/org/dynjs/runtime/java/JavaIntegrationTest.java
+++ b/src/test/java/org/dynjs/runtime/java/JavaIntegrationTest.java
@@ -185,15 +185,23 @@ public class JavaIntegrationTest extends AbstractDynJSTestSupport {
 
     @Test
     public void testJavaArrayCoercionInMethodCalls() {
-        eval("arr = ['foo', 'bar']");
         eval("thing = new org.dynjs.runtime.java.Thing()");
-        assertThat(eval("thing.joiner(arr)")).isEqualTo("foobar");
+        assertThat(eval("thing.stringJoiner(['foo', 'bar'])")).isEqualTo("foobar");
+        // now make sure primitives work
+        assertThat(eval("thing.booleanJoiner([true, false])")).isEqualTo("truefalse");
+        assertThat(eval("thing.byteJoiner([1, 2, 3])")).isEqualTo("123");
+        assertThat(eval("thing.charJoiner(['a', 'b', 'c'])")).isEqualTo("abc");
+        assertThat(eval("thing.doubleJoiner([1.2, 2.3, 3.4])")).isEqualTo("1.22.33.4");
+        assertThat(eval("thing.floatJoiner([1.2, 2.3, 3.4])")).isEqualTo("1.22.33.4");
+        assertThat(eval("thing.intJoiner([1, 2, 3])")).isEqualTo("123");
+        assertThat(eval("thing.longJoiner([1, 2, 3])")).isEqualTo("123");
+        assertThat(eval("thing.shortJoiner([1, 2, 3])")).isEqualTo("123");
     }
 
     @Test
-    @Ignore
     public void testJavaArrayCoercionInCtor() {
-        assertThat(eval("new org.dynjs.runtime.java.Thing([1, 2, 3])")).isInstanceOf(Thing.class);
+        eval("new org.dynjs.runtime.java.Thing()");
+        assertThat(eval("new org.dynjs.runtime.java.Thing([new java.util.ArrayList()])")).isInstanceOf(Thing.class);
     }
 
     @Test

--- a/src/test/java/org/dynjs/runtime/java/Thing.java
+++ b/src/test/java/org/dynjs/runtime/java/Thing.java
@@ -1,5 +1,8 @@
 package org.dynjs.runtime.java;
 
+import java.lang.reflect.Array;
+import java.util.List;
+
 import org.dynjs.runtime.DynObject;
 
 public class Thing {
@@ -13,7 +16,7 @@ public class Thing {
         super();
     }
 
-    public Thing(int[] numbers) {
+    public Thing(List[] lists) {
         super();
     }
     
@@ -29,10 +32,47 @@ public class Thing {
         return obj.get("foo");
     }
 
-    public String joiner(String []strings) {
+    public String stringJoiner(String[] strings) {
+        return joinArray(strings);
+    }
+
+    public String booleanJoiner(boolean[] bools) {
+        return joinArray(bools);
+    }
+
+    public String byteJoiner(byte[] bytes) {
+        return joinArray(bytes);
+    }
+
+    public String charJoiner(char[] chars) {
+        return joinArray(chars);
+    }
+
+    public String doubleJoiner(double[] doubles) {
+        return joinArray(doubles);
+    }
+
+    public String floatJoiner(float[] floats) {
+        return joinArray(floats);
+    }
+
+    public String intJoiner(int[] ints) {
+        return joinArray(ints);
+    }
+
+    public String longJoiner(long[] longs) {
+        return joinArray(longs);
+    }
+
+    public String shortJoiner(short[] shorts) {
+        return joinArray(shorts);
+    }
+
+    protected String joinArray(Object array) {
+        int length = Array.getLength(array);
         StringBuffer buffer = new StringBuffer();
-        for (int i = 0; i < strings.length; i++) {
-            buffer.append(strings[i]);
+        for (int i = 0; i < length; i++) {
+            buffer.append("" + Array.get(array, i));
         }
         return buffer.toString();
     }


### PR DESCRIPTION
This also fixes issues with passing DynArrays to Java methods
expecting primitive arrays (ie int[], boolean[], etc).

This should be the last change needed to fix DYNJS-118.
