### PR TITLE
Fix for JavaClassModuleProvider registering functions in module exports.

### DIFF
--- a/src/main/java/org/dynjs/runtime/modules/JavaClassModuleProvider.java
+++ b/src/main/java/org/dynjs/runtime/modules/JavaClassModuleProvider.java
@@ -50,8 +50,8 @@ public class JavaClassModuleProvider extends ModuleProvider {
     private JSObject buildExports(ExecutionContext context, String moduleName, Object javaModule) throws IllegalAccessException {
         Method[] methods = javaModule.getClass().getMethods();
 
-        JSObject module  = (JSObject) context.getGlobalObject().get("module");
-        JSObject exports = (JSObject) module.get(null, "exports");
+		JSObject module = (JSObject) context.getVariableEnvironment().getRecord().getBindingValue(context, "module", true);
+		JSObject exports = (JSObject) module.get(context, "exports");
 
         for (Method method : methods) {
             Export exportAnno = method.getAnnotation(Export.class);


### PR DESCRIPTION
In DynJS 2.3.0 the scoping of variables was implemented and the VariableEnvironment got introduced. Along these changes updating the JavaClassModuleProvider was forgotten. Before my fix, the module.exports object of the global environment was extracted and the exports added to it. However, the code in ModuleProvider.findAndLoad() uses the local environment for providing the module object and later on fetching the exports object. This exports object is empty in all cases! As a result all my internal APIs failed miserably.

It took a while to figure this out, please merge the change fixing the issue for other people as well. I like DynJS a lot, it's great work!

Best regards,
   Thomas.
