### PR TITLE
resolve . and .. in relative paths to canonical form to generate comparable module ids.

### DIFF
--- a/src/main/java/org/dynjs/runtime/modules/FilesystemModuleProvider.java
+++ b/src/main/java/org/dynjs/runtime/modules/FilesystemModuleProvider.java
@@ -34,13 +34,17 @@ public class FilesystemModuleProvider extends ModuleProvider {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public String generateModuleID(ExecutionContext context, String moduleName) {
         Object require = context.getGlobalObject().get("require");
         if (require instanceof Require) {
             File moduleFile = findFile(((Require)require).getLoadPaths(), moduleName);
             if (moduleFile != null && moduleFile.exists()) {
-                return moduleFile.getAbsolutePath();
+                try {
+                    return moduleFile.getCanonicalPath();
+                } catch(IOException e) {
+                    System.err.println("There was an error generating id of module " + moduleName + ". Error message: " + e.getMessage());
+                    return moduleFile.getAbsolutePath();
+                }
             }
         }
         return null;


### PR DESCRIPTION
Hi,

I noticed in NPMs sometimes stuff like require('./lib/express') is used. This leads to absolute paths containing the . folder name causing the generated module IDs sometimes not matching. This affects mostly the NPM stuff in NoDyn, but it could be an issue in FilesystemModuleProvider as well. Thus, I compute the canonical path here to fix both places. Nice, if you'd merge it.

Regards,
   Thomas.
