### PR TITLE
Don't evaluate nested variable declarations in ForVarDeclStatement (fixes #95)

### DIFF
--- a/src/main/java/org/dynjs/codegen/BasicBytecodeGeneratingVisitor.java
+++ b/src/main/java/org/dynjs/codegen/BasicBytecodeGeneratingVisitor.java
@@ -1199,7 +1199,7 @@ public class BasicBytecodeGeneratingVisitor extends CodeGeneratingVisitor {
 
     @Override
     public void visit(ExecutionContext context, ForVarDeclStatement statement, boolean strict) {
-        List<VariableDeclaration> decls = statement.getVariableDeclarations();
+        List<VariableDeclaration> decls = statement.getDeclarationList();
         for (VariableDeclaration each : decls) {
             each.accept(context, this, strict);
             pop();

--- a/src/test/java/org/dynjs/runtime/AbstractDynJSTestSupport.java
+++ b/src/test/java/org/dynjs/runtime/AbstractDynJSTestSupport.java
@@ -18,12 +18,17 @@ public abstract class AbstractDynJSTestSupport {
 
     @Before
     public void setUp() {
-        this.config = new Config();
-        this.config.setDebug(false);
+        this.config = createConfig();
+        this.runtime = new DynJS(this.config);
+    }
+
+    protected Config createConfig() {
+        Config config = new Config();
+        config.setDebug(false);
         config.setClock(new ManualClock(fixedInstant));
         config.setTimeZone(TimeZone.getTimeZone("America/Sao_Paulo"));
         config.setLocale(Locale.US);
-        this.runtime = new DynJS(this.config);
+        return config;
     }
 
     protected Object eval(String... lines) {

--- a/src/test/java/org/dynjs/runtime/ForVarDeclStatementBytecodeCompilerTest.java
+++ b/src/test/java/org/dynjs/runtime/ForVarDeclStatementBytecodeCompilerTest.java
@@ -1,0 +1,29 @@
+package org.dynjs.runtime;
+
+import static org.fest.assertions.Assertions.*;
+
+import org.dynjs.Config;
+import org.junit.Test;
+
+public class ForVarDeclStatementBytecodeCompilerTest extends AbstractDynJSTestSupport {
+
+    @Override
+    protected Config createConfig() {
+        Config config = super.createConfig();
+        config.setCompileMode(Config.CompileMode.FORCE);
+        return config;
+    }
+
+    @Test
+    public void testBasicLoop() {
+        eval("for (var i = 0; false; ) {",
+             "  var y = (i = 1);",
+             "}");
+
+        Object i = getContext().resolve("i").getValue(getContext());
+        assertThat(i).isEqualTo(0L);
+
+        Object y = getContext().resolve("y").getValue(getContext());
+        assertThat(y).isEqualTo(Types.UNDEFINED);
+    }
+}


### PR DESCRIPTION
Inner variable declarations must not be evaluated when processing the for-loop's declaration list. Slightly modified AbstractDynJSTestSupport to be able to change the compilation mode to bytecode compilation instead of interpreter/jit.
