### PR TITLE
Pre-parse numeric literals and represent them as first-class citizens in AST

### DIFF
--- a/src/main/java/org/dynjs/codegen/BasicBytecodeGeneratingVisitor.java
+++ b/src/main/java/org/dynjs/codegen/BasicBytecodeGeneratingVisitor.java
@@ -33,6 +33,7 @@ import org.dynjs.parser.ast.EmptyStatement;
 import org.dynjs.parser.ast.EqualityOperatorExpression;
 import org.dynjs.parser.ast.Expression;
 import org.dynjs.parser.ast.ExpressionStatement;
+import org.dynjs.parser.ast.FloatingNumberExpression;
 import org.dynjs.parser.ast.ForExprInStatement;
 import org.dynjs.parser.ast.ForExprStatement;
 import org.dynjs.parser.ast.ForVarDeclInStatement;
@@ -44,6 +45,7 @@ import org.dynjs.parser.ast.IdentifierReferenceExpression;
 import org.dynjs.parser.ast.IfStatement;
 import org.dynjs.parser.ast.InOperatorExpression;
 import org.dynjs.parser.ast.InstanceofExpression;
+import org.dynjs.parser.ast.IntegerNumberExpression;
 import org.dynjs.parser.ast.LogicalExpression;
 import org.dynjs.parser.ast.LogicalNotOperatorExpression;
 import org.dynjs.parser.ast.MultiplicativeExpression;
@@ -889,6 +891,11 @@ public class BasicBytecodeGeneratingVisitor extends CodeGeneratingVisitor {
     }
 
     @Override
+    public void visit(ExecutionContext context, FloatingNumberExpression expr, boolean strict) {
+        visit(context, (NumberLiteralExpression) expr, strict);
+    }
+
+    @Override
     public void visit(ExecutionContext context, ForExprInStatement statement, boolean strict) {
         LabelNode nextName = new LabelNode();
         LabelNode checkCompletion = new LabelNode();
@@ -1616,6 +1623,11 @@ public class BasicBytecodeGeneratingVisitor extends CodeGeneratingVisitor {
     }
 
     @Override
+    public void visit(ExecutionContext context, IntegerNumberExpression expr, boolean strict) {
+        visit(context, (NumberLiteralExpression) expr, strict);
+    }
+
+    @Override
     public void visit(ExecutionContext context, LogicalExpression expr, boolean strict) {
         LabelNode end = new LabelNode();
 
@@ -1812,7 +1824,6 @@ public class BasicBytecodeGeneratingVisitor extends CodeGeneratingVisitor {
         getstatic(p(Types.class), "NULL", ci(Types.Null.class));
     }
 
-    @Override
     public void visit(ExecutionContext context, NumberLiteralExpression expr, boolean strict) {
         String text = expr.getText();
 

--- a/src/main/java/org/dynjs/parser/CodeVisitor.java
+++ b/src/main/java/org/dynjs/parser/CodeVisitor.java
@@ -21,6 +21,7 @@ import org.dynjs.parser.ast.DotExpression;
 import org.dynjs.parser.ast.EmptyStatement;
 import org.dynjs.parser.ast.EqualityOperatorExpression;
 import org.dynjs.parser.ast.ExpressionStatement;
+import org.dynjs.parser.ast.FloatingNumberExpression;
 import org.dynjs.parser.ast.ForExprInStatement;
 import org.dynjs.parser.ast.ForExprStatement;
 import org.dynjs.parser.ast.ForVarDeclInStatement;
@@ -32,6 +33,7 @@ import org.dynjs.parser.ast.IdentifierReferenceExpression;
 import org.dynjs.parser.ast.IfStatement;
 import org.dynjs.parser.ast.InOperatorExpression;
 import org.dynjs.parser.ast.InstanceofExpression;
+import org.dynjs.parser.ast.IntegerNumberExpression;
 import org.dynjs.parser.ast.LogicalExpression;
 import org.dynjs.parser.ast.LogicalNotOperatorExpression;
 import org.dynjs.parser.ast.MultiplicativeExpression;
@@ -105,6 +107,8 @@ public interface CodeVisitor {
 
     void visit(ExecutionContext context, ExpressionStatement statement, boolean strict);
 
+    void visit(ExecutionContext context, FloatingNumberExpression expr, boolean strict);
+
     void visit(ExecutionContext context, ForExprInStatement statement, boolean strict);
 
     void visit(ExecutionContext context, ForExprStatement statement, boolean strict);
@@ -127,6 +131,8 @@ public interface CodeVisitor {
 
     void visit(ExecutionContext context, InstanceofExpression expr, boolean strict);
 
+    void visit(ExecutionContext context, IntegerNumberExpression expr, boolean strict);
+
     void visit(ExecutionContext context, LogicalExpression expr, boolean strict);
 
     void visit(ExecutionContext context, LogicalNotOperatorExpression expr, boolean strict);
@@ -140,8 +146,6 @@ public interface CodeVisitor {
     void visit(ExecutionContext context, NewOperatorExpression expr, boolean strict);
 
     void visit(ExecutionContext context, NullLiteralExpression expr, boolean strict);
-
-    void visit(ExecutionContext context, NumberLiteralExpression expr, boolean strict);
 
     void visit(ExecutionContext context, ObjectLiteralExpression expr, boolean strict);
 

--- a/src/main/java/org/dynjs/parser/DefaultVisitor.java
+++ b/src/main/java/org/dynjs/parser/DefaultVisitor.java
@@ -24,6 +24,7 @@ import org.dynjs.parser.ast.EmptyStatement;
 import org.dynjs.parser.ast.EqualityOperatorExpression;
 import org.dynjs.parser.ast.Expression;
 import org.dynjs.parser.ast.ExpressionStatement;
+import org.dynjs.parser.ast.FloatingNumberExpression;
 import org.dynjs.parser.ast.ForExprInStatement;
 import org.dynjs.parser.ast.ForExprStatement;
 import org.dynjs.parser.ast.ForVarDeclInStatement;
@@ -35,6 +36,7 @@ import org.dynjs.parser.ast.IdentifierReferenceExpression;
 import org.dynjs.parser.ast.IfStatement;
 import org.dynjs.parser.ast.InOperatorExpression;
 import org.dynjs.parser.ast.InstanceofExpression;
+import org.dynjs.parser.ast.IntegerNumberExpression;
 import org.dynjs.parser.ast.LogicalExpression;
 import org.dynjs.parser.ast.LogicalNotOperatorExpression;
 import org.dynjs.parser.ast.MultiplicativeExpression;
@@ -183,6 +185,11 @@ public class DefaultVisitor implements CodeVisitor {
     }
 
     @Override
+    public void visit(ExecutionContext context, FloatingNumberExpression expr, boolean strict) {
+        // no-op
+    }
+
+    @Override
     public void visit(ExecutionContext context, ForExprInStatement statement, boolean strict) {
         statement.getExpr().accept(context, this, strict);
         statement.getRhs().accept(context, this, strict);
@@ -275,6 +282,11 @@ public class DefaultVisitor implements CodeVisitor {
     }
 
     @Override
+    public void visit(ExecutionContext context, IntegerNumberExpression expr, boolean strict) {
+        // no-op
+    }
+
+    @Override
     public void visit(ExecutionContext context, LogicalExpression expr, boolean strict) {
         walkBinaryExpression(context, expr, strict);
     }
@@ -307,11 +319,6 @@ public class DefaultVisitor implements CodeVisitor {
 
     @Override
     public void visit(ExecutionContext context, NullLiteralExpression expr, boolean strict) {
-        // no-op
-    }
-
-    @Override
-    public void visit(ExecutionContext context, NumberLiteralExpression expr, boolean strict) {
         // no-op
     }
 

--- a/src/main/java/org/dynjs/parser/ast/FloatingNumberExpression.java
+++ b/src/main/java/org/dynjs/parser/ast/FloatingNumberExpression.java
@@ -1,0 +1,24 @@
+package org.dynjs.parser.ast;
+
+import org.dynjs.parser.CodeVisitor;
+import org.dynjs.parser.js.Position;
+import org.dynjs.runtime.ExecutionContext;
+
+public class FloatingNumberExpression extends NumberLiteralExpression {
+    double value;
+
+    public FloatingNumberExpression(Position position, String text, int radix, double value) {
+        super(position, text, radix);
+
+        this.value = value;
+    }
+
+    @Override
+    public void accept(ExecutionContext context, CodeVisitor visitor, boolean strict) {
+        visitor.visit( context, this, strict );
+    }
+
+    public double getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/dynjs/parser/ast/IntegerNumberExpression.java
+++ b/src/main/java/org/dynjs/parser/ast/IntegerNumberExpression.java
@@ -1,0 +1,24 @@
+package org.dynjs.parser.ast;
+
+import org.dynjs.parser.CodeVisitor;
+import org.dynjs.parser.js.Position;
+import org.dynjs.runtime.ExecutionContext;
+
+public class IntegerNumberExpression extends NumberLiteralExpression {
+    private long value;
+
+    public IntegerNumberExpression(Position position, String text, int radix, long value) {
+        super(position, text, radix);
+
+        this.value = value;
+    }
+
+    @Override
+    public void accept(ExecutionContext context, CodeVisitor visitor, boolean strict) {
+        visitor.visit( context, this, strict );
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/dynjs/parser/ast/NumberLiteralExpression.java
+++ b/src/main/java/org/dynjs/parser/ast/NumberLiteralExpression.java
@@ -19,13 +19,17 @@ import org.dynjs.parser.CodeVisitor;
 import org.dynjs.parser.js.Position;
 import org.dynjs.runtime.ExecutionContext;
 
-public class NumberLiteralExpression extends BaseExpression {
+public abstract class NumberLiteralExpression extends BaseExpression {
 
     private final String text;
+    // FIXME: Radix is unneeded since concrete types already know their value.
+    // This is only left in for current JIT to continue working and should be
+    // removed once the new IR is working.
     private final int radix;
 
     public NumberLiteralExpression(Position position, String text, int radix) {
         super(position);
+
         this.text = text;
         this.radix = radix;
     }
@@ -33,7 +37,7 @@ public class NumberLiteralExpression extends BaseExpression {
     public String getText() {
         return this.text;
     }
-    
+
     public int getRadix() {
         return this.radix;
     }
@@ -44,10 +48,5 @@ public class NumberLiteralExpression extends BaseExpression {
     
     public int getSizeMetric() {
         return 3;
-    }
-
-    @Override
-    public void accept(ExecutionContext context, CodeVisitor visitor, boolean strict) {
-        visitor.visit( context, this, strict );
     }
 }

--- a/src/main/java/org/dynjs/runtime/interp/BasicInterpretingVisitor.java
+++ b/src/main/java/org/dynjs/runtime/interp/BasicInterpretingVisitor.java
@@ -28,6 +28,7 @@ import org.dynjs.parser.ast.EmptyStatement;
 import org.dynjs.parser.ast.EqualityOperatorExpression;
 import org.dynjs.parser.ast.Expression;
 import org.dynjs.parser.ast.ExpressionStatement;
+import org.dynjs.parser.ast.FloatingNumberExpression;
 import org.dynjs.parser.ast.ForExprInStatement;
 import org.dynjs.parser.ast.ForExprStatement;
 import org.dynjs.parser.ast.ForVarDeclInStatement;
@@ -39,6 +40,7 @@ import org.dynjs.parser.ast.IdentifierReferenceExpression;
 import org.dynjs.parser.ast.IfStatement;
 import org.dynjs.parser.ast.InOperatorExpression;
 import org.dynjs.parser.ast.InstanceofExpression;
+import org.dynjs.parser.ast.IntegerNumberExpression;
 import org.dynjs.parser.ast.LogicalExpression;
 import org.dynjs.parser.ast.LogicalNotOperatorExpression;
 import org.dynjs.parser.ast.MultiplicativeExpression;
@@ -478,6 +480,11 @@ public class BasicInterpretingVisitor implements InterpretingVisitor {
     }
 
     @Override
+    public void visit(ExecutionContext context, FloatingNumberExpression expr, boolean strict) {
+        push(expr.getValue());
+    }
+
+    @Override
     public void visit(ExecutionContext context, ForExprInStatement statement, boolean strict) {
         statement.getRhs().accept(context, this, strict);
 
@@ -802,6 +809,11 @@ public class BasicInterpretingVisitor implements InterpretingVisitor {
     }
 
     @Override
+    public void visit(ExecutionContext context, IntegerNumberExpression expr, boolean strict) {
+        push(expr.getValue());
+    }
+
+    @Override
     public void visit(ExecutionContext context, LogicalExpression expr, boolean strict) {
         expr.getLhs().accept(context, this, strict);
         Object lhs = getValue(context, pop());
@@ -980,46 +992,6 @@ public class BasicInterpretingVisitor implements InterpretingVisitor {
     @Override
     public void visit(ExecutionContext context, NullLiteralExpression expr, boolean strict) {
         push(Types.NULL);
-    }
-
-    @Override
-    public void visit(ExecutionContext context, NumberLiteralExpression expr, boolean strict) {
-        String text = expr.getText();
-
-        if (text.indexOf('.') == 0) {
-            text = "0" + text;
-            push(Double.valueOf(text));
-            return;
-        }
-
-        if (text.indexOf('.') > 0) {
-            double primaryValue = Double.valueOf(text);
-            if (primaryValue == (long) primaryValue) {
-                push((long) primaryValue);
-            } else {
-                push(primaryValue);
-            }
-            return;
-        }
-
-        if (text.startsWith("0x") || text.startsWith("0X")) {
-            text = text.substring(2);
-            push(Long.valueOf(text, 16));
-            return;
-        }
-
-        int eLoc = text.toLowerCase().indexOf('e');
-        if (eLoc > 0) {
-
-            String base = text.substring(0, eLoc);
-            String exponent = text.substring(eLoc);
-
-            String javafied = base + ".0" + exponent;
-
-            push(Double.valueOf(javafied));
-        } else {
-            push(Types.parseLongOrDouble(text, expr.getRadix()));
-        }
     }
 
     @Override


### PR DESCRIPTION
Replace NumberLiteralExpression with {Float,Integer}NumberExpression and pre-parse those values.
