### PR TITLE
Fix JSON.stringify not working for dates

### DIFF
--- a/src/main/java/org/dynjs/runtime/builtins/types/date/UTC.java
+++ b/src/main/java/org/dynjs/runtime/builtins/types/date/UTC.java
@@ -51,7 +51,7 @@ public class UTC extends AbstractDateFunction {
         }
 
         Number finalDate = makeDate(context, makeDay(context, yr, m, dt), makeTime(context, h, min, s, milli));
-        Number clipped = timeClip(context, utc(context, finalDate));
+        Number clipped = timeClip(context, finalDate);
 
         return clipped;
     }

--- a/src/main/java/org/dynjs/runtime/builtins/types/date/prototype/ToJSON.java
+++ b/src/main/java/org/dynjs/runtime/builtins/types/date/prototype/ToJSON.java
@@ -25,7 +25,7 @@ public class ToJSON extends AbstractDateFunction {
             }
         }
 
-        Object toISO = get(context, "toISOString");
+        Object toISO = o.get(context, "toISOString");
         if (!(toISO instanceof JSFunction)) {
             throw new ThrowException(context, context.createTypeError("toISOString must be a function"));
         }

--- a/src/test/java/org/dynjs/runtime/builtins/types/BuiltinDateTest.java
+++ b/src/test/java/org/dynjs/runtime/builtins/types/BuiltinDateTest.java
@@ -251,4 +251,9 @@ public class BuiltinDateTest extends AbstractDynJSTestSupport {
     public void testDateSetUTCFullYear() {
         assertThat(eval("new Date().setUTCFullYear(2012)")).isEqualTo(fixedInstant);
     }
+
+    @Test
+    public void testDateUTC() {
+        assertThat(eval("Date.UTC(1980, 2, 11, 8, 33, 12)")).isEqualTo(321611592000L);
+    }
 }

--- a/src/test/java/org/dynjs/runtime/builtins/types/JSONTest.java
+++ b/src/test/java/org/dynjs/runtime/builtins/types/JSONTest.java
@@ -112,4 +112,10 @@ public class JSONTest extends AbstractDynJSTestSupport {
         assertThat(result).doesNotContain("\n");
     }
 
+    @Test
+    public void testStringifyDate() {
+        String result = (String) eval("JSON.stringify(new Date(Date.UTC(1980, 2, 11)))");
+        assertThat(result).isEqualTo("\"1980-03-11T00:00:00.000Z\"");
+    }
+
 }


### PR DESCRIPTION
The code for ToJSON didn't use the proper object when resolving the toISOString method. This caused stringify to fail on date values.

Also, while writing a test I noticed that the Date.utc function wrongly applied an offset based on the current timezone, so I fixed thta too. The value I'm checking against in tests is the one returned by Node, Chrome and Firefox.
