### PR TITLE
Fix the "m" flag in regexps for correct multiline behavior (#138)

### DIFF
--- a/src/main/java/org/dynjs/runtime/builtins/types/regexp/DynRegExp.java
+++ b/src/main/java/org/dynjs/runtime/builtins/types/regexp/DynRegExp.java
@@ -70,8 +70,12 @@ public class DynRegExp extends DynObject {
 
         int flagsInt = 0;
 
+        // joni calls the "m" flag Option.SINGLELINE, confusingly enough
+        // joni's Option.MULTILINE is actually Perl's "s" regex flag which
+        // has no equivalent in javascript
         if (get(context, "multiline") == Boolean.TRUE) {
-            flagsInt = flagsInt | Option.MULTILINE;
+            // negate Option.SINGLELINE
+            flagsInt = flagsInt & ~Option.SINGLELINE;
         } else {
             flagsInt = flagsInt | Option.SINGLELINE;
         }

--- a/src/test/javascript/org/dynjs/regexSpec.js
+++ b/src/test/javascript/org/dynjs/regexSpec.js
@@ -1,24 +1,68 @@
-describe("String.prototype.replace with regular expressions", function() {
-  it("should handle simple string replacements with functions", function() {
-    var x = ":res[content-length] :referrer[google.com]";
-    var y = x.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/, function(_, a, b, c, d) {
-      expect(_).toBe(":res[content-length]");
-      expect(a).toBe("res");
-      expect(b).toBe("content-length");
-      expect(c).toBe(0);
-      expect(d).toBe(":res[content-length] :referrer[google.com]");
-      return a + "." + b;
+describe("regular expressions", function() {
+
+  describe("String.prototype.replace with regular expressions", function() {
+    it("should handle simple string replacements with functions", function() {
+      var x = ":res[content-length] :referrer[google.com]";
+      var y = x.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/, function(_, a, b, c, d) {
+        expect(_).toBe(":res[content-length]");
+        expect(a).toBe("res");
+        expect(b).toBe("content-length");
+        expect(c).toBe(0);
+        expect(d).toBe(":res[content-length] :referrer[google.com]");
+        return a + "." + b;
+      });
+      expect(y).toBe("res.content-length :referrer[google.com]");
     });
-    expect(y).toBe("res.content-length :referrer[google.com]");
+
+    it("should handle global string replacements with functions", function() {
+      var x = ":remote-addr - - [:date] :res[content-length] - - :foo[bar] :referrer[google.com]";
+      var y = x.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function(_, a, b, c, d) {
+        return a + "." + b;
+      });
+      print(y);
+      expect(y).toBe("remote-addr.undefined - - [date.undefined] res.content-length - - foo.bar referrer.google.com");
+    });
   });
 
-  it("should handle global string replacements with functions", function() {
-    var x = ":remote-addr - - [:date] :res[content-length] - - :foo[bar] :referrer[google.com]";
-    var y = x.replace(/:([-\w]{2,})(?:\[([^\]]+)\])?/g, function(_, a, b, c, d) {
-      return a + "." + b;
+  describe("multiline", function() {
+    it("should not match newlines with dot character", function() {
+      var multiline = "FOO=bar\nFOOBAR=boom\n";
+      var regex = new RegExp(/([\w+]+)\s*\=\s*(.*)/gi);
+      var regexWithM = new RegExp(/([\w+]+)\s*\=\s*(.*)/gmi);
+      var verifyExec = function(arr) {
+        expect(arr.length).toBe(3);
+        expect(arr[0]).toBe("FOO=bar");
+        expect(arr[1]).toBe("FOO");
+        expect(arr[2]).toBe("bar");
+      };
+      var verifyMatch = function(arr) {
+        expect(arr.length).toBe(2);
+        expect(arr[0]).toBe("FOO=bar");
+        expect(arr[1]).toBe("FOOBAR=boom");
+      };
+      verifyExec(regex.exec(multiline));
+      verifyExec(regexWithM.exec(multiline));
+      verifyMatch(multiline.match(regex));
+      verifyMatch(multiline.match(regexWithM));
+
     });
-    print(y);
-    expect(y).toBe("remote-addr.undefined - - [date.undefined] res.content-length - - foo.bar referrer.google.com");
+
+    it("should match ^ for first line without multiline flag", function() {
+      var multiline = "FOO=bar\nFOOBAR=boom\n";
+      var regex = new RegExp(/^([\w+]+)\s*\=\s*(.*)/gi);
+      var arr = multiline.match(regex);
+      expect(arr.length).toBe(1);
+      expect(arr[0]).toBe("FOO=bar");
+    });
+
+    it("should match ^ for all lines with multiline flag", function() {
+      var multiline = "FOO=bar\nFOOBAR=boom\n";
+      var regex = new RegExp(/^([\w+]+)\s*\=\s*(.*)/gim);
+      var arr = multiline.match(regex);
+      expect(arr.length).toBe(2);
+      expect(arr[0]).toBe("FOO=bar");
+      expect(arr[1]).toBe("FOOBAR=boom");
+    });
   });
 
 });


### PR DESCRIPTION
When the "m" flag was present in a regexp we were setting Joni's
Option.MULTILINE when we really should have been negating Joni's
Option.SINGLELINE. The naming of the options in Joni is confusing when
compared to the options used in JS regexps.

Fixes #138
