### PR TITLE
Ensure we handle __proto__ when set in an object literal

### DIFF
--- a/src/main/java/org/dynjs/parser/ast/ObjectLiteralExpression.java
+++ b/src/main/java/org/dynjs/parser/ast/ObjectLiteralExpression.java
@@ -71,15 +71,19 @@ public class ObjectLiteralExpression extends BaseExpression {
             }
             Object value = getValue(eachGet, context, ref);
             Object original = obj.getOwnProperty(context, each.getName());
-            PropertyDescriptor desc = null;
-            if (each instanceof PropertyGet) {
-                desc = PropertyDescriptor.newPropertyDescriptorForObjectInitializerGet(original, debugName, (JSFunction) value);
-            } else if (each instanceof PropertySet) {
-                desc = PropertyDescriptor.newPropertyDescriptorForObjectInitializerSet(original, debugName, (JSFunction) value);
+            if (each.getName().equals("__proto__")) {
+                obj.put(context, each.getName(), value, false);
             } else {
-                desc = PropertyDescriptor.newPropertyDescriptorForObjectInitializer(debugName, value);
+                PropertyDescriptor desc = null;
+                if (each instanceof PropertyGet) {
+                    desc = PropertyDescriptor.newPropertyDescriptorForObjectInitializerGet(original, debugName, (JSFunction) value);
+                } else if (each instanceof PropertySet) {
+                    desc = PropertyDescriptor.newPropertyDescriptorForObjectInitializerSet(original, debugName, (JSFunction) value);
+                } else {
+                    desc = PropertyDescriptor.newPropertyDescriptorForObjectInitializer(debugName, value);
+                }
+                obj.defineOwnProperty(context, each.getName(), desc, false);
             }
-            obj.defineOwnProperty(context, each.getName(), desc, false);
         }
 
         return(obj);

--- a/src/test/javascript/org/dynjs/extensionsSpec.js
+++ b/src/test/javascript/org/dynjs/extensionsSpec.js
@@ -143,6 +143,12 @@ describe("the __proto__ property", function() {
     expect(x.hasOwnProperty('__proto__')).toBe(true);
   });
 
+  it("should update prototype for object literals with __proto__", function() {
+    var proto = { foo: 'bar' };
+    var a = { __proto__: proto };
+    expect(Object.getPrototypeOf(a)).toBe(proto);
+  });
+
   xit("should allow Object.prototype.__proto__ to be set", function() {
     // TODO: This test should pass, and replicating it in the REPL
     // shows that it works as expected. However, the Jasmine test


### PR DESCRIPTION
When an object literal is created, we need to check for the **proto**
property and if set ensure that goes through our normal **proto**
handling logic. This feels like a hack to check for **proto**
explicitly but does get the included spec and the nodyn-examples
express example app working.

Suggestions for improvement are most welcome.
