### PR TITLE
fix for #getMethodCallSyntax() - use all args[]

### DIFF
--- a/src/main/java/org/dynjs/jsr223/DynJSScriptEngineFactory.java
+++ b/src/main/java/org/dynjs/jsr223/DynJSScriptEngineFactory.java
@@ -104,7 +104,7 @@ public class DynJSScriptEngineFactory implements ScriptEngineFactory {
             if ( i > 0 ) {
                 builder.append( "," );
             }
-            builder.append( args[0] );
+            builder.append( args[i] );
         }
         builder.append( ")" );
 


### PR DESCRIPTION
use all args[], not just the 1st one
