### PR TITLE
fix and unit test for parsing long numbers in JSON.Parse

### DIFF
--- a/src/main/java/org/dynjs/runtime/builtins/types/json/Parse.java
+++ b/src/main/java/org/dynjs/runtime/builtins/types/json/Parse.java
@@ -131,10 +131,8 @@ public class Parse extends AbstractNativeFunction {
             return Types.NULL;
         } else if (t == JsonToken.VALUE_STRING) {
             return p.getText();
-        } else if (t == JsonToken.VALUE_NUMBER_FLOAT) {
-            return p.getDoubleValue();
-        } else if (t == JsonToken.VALUE_NUMBER_INT) {
-            return p.getIntValue();
+        } else if (t == JsonToken.VALUE_NUMBER_FLOAT || t == JsonToken.VALUE_NUMBER_INT) {
+            return p.getNumberValue();
         }
 
         return Types.NULL;

--- a/src/test/java/org/dynjs/runtime/builtins/types/JSONTest.java
+++ b/src/test/java/org/dynjs/runtime/builtins/types/JSONTest.java
@@ -64,6 +64,14 @@ public class JSONTest extends AbstractDynJSTestSupport {
     }
 
     @Test
+    public void testParseLongValue() {
+        JSObject result = (JSObject) eval("JSON.parse('{\"foo\": 1234567890123, \"bar\": \"cheese\"}')");
+
+        assertThat(result.get(getContext(), "foo")).isEqualTo(1234567890123L);
+        assertThat(result.get(getContext(), "bar")).isEqualTo("cheese");
+    }
+
+    @Test
     public void testStringifyArray() {
         String result = (String) eval("JSON.stringify( [1, 'foo', 3] )");
         assertThat(result).isEqualTo("[1,\"foo\",3]");


### PR DESCRIPTION
JSON.Parse was reading all non-float number values as Java Integers. This caused a parse exception on long values, because they overflowed Integer.

Jackson's getNumberValue() will read float, int, long, etc. properly: "It will return the optimal (simplest/smallest possible) wrapper object that can express the numeric value just parsed."

I switched the org.dynjs.runtime.builtins.types.json.Parse parseValue() to use it for both number token types and added a unit test that covers the issue.
