### PR TITLE
One more fix for regex containing accented characters

### DIFF
--- a/src/main/java/org/dynjs/runtime/builtins/types/regexp/DynRegExp.java
+++ b/src/main/java/org/dynjs/runtime/builtins/types/regexp/DynRegExp.java
@@ -153,7 +153,7 @@ public class DynRegExp extends DynObject {
             strBytes = str.getBytes(charset);
 
             // Be careful to convert index just outside of string to one
-            // just outside of by array (substring complains otherwise).
+            // just outside of the array (substring complains otherwise).
             if (from > str.length()) {
                 adjustedFrom = strBytes.length + 1;
             } else {

--- a/src/test/javascript/org/dynjs/regexSpec.js
+++ b/src/test/javascript/org/dynjs/regexSpec.js
@@ -24,9 +24,9 @@ describe("regular expressions", function() {
     });
 
     it("should work fine with multi-byte UTF-8 characters", function() {
-        var x = "foo ohé foobar";
-        var y = x.replace(/foo/g, "bar");
-        expect(y).toBe("bar ohé barbar");
+      expect("foo ohé foobar".replace(/foo/g, "baar")).toBe("baar ohé baarbar");
+      expect("éeéeé".replace(/[A-Za-z]+/gi, "foo")).toBe("éfooéfooé");
+      expect("éeéeé".replace(/[A-Za-z]+/gi, "ohé")).toBe("éohééohéé");
     });
   });
 
@@ -70,7 +70,6 @@ describe("regular expressions", function() {
       expect(arr[1]).toBe("FOOBAR=boom");
     });
   });
-
 });
 
 describe("String.prototype.match", function() {
@@ -81,6 +80,10 @@ describe("String.prototype.match", function() {
 
     expect(lines).toBeTruthy();
     expect(lines.length).toBe(3);
+  });
+
+  it("should work with strings containing multi-byte UTF-8 characters", function() {
+    expect("mémoire de frais".match(/[\wé]+/gi)).toEqual(["mémoire", "de", "frais"]);
   });
 });
 


### PR DESCRIPTION
Following my previous PR (https://github.com/dynjs/dynjs/pull/150) I've found another issue with the DynRegExp.match method. The `from` offset is not adjusted in the by array to account for multibyte characters. I fixed that a while ago but somehow I totally forgot to submit it here, so here goes.