### PR TITLE
Add support for sandboxing and resource quotas

### DIFF
--- a/src/main/java/org/dynjs/Config.java
+++ b/src/main/java/org/dynjs/Config.java
@@ -41,6 +41,7 @@ public class Config {
     private boolean jitEnabled = Options.JIT.load();
     private boolean jitAsync = Options.JIT_ASYNC.load();
     private boolean v8Compatible = Options.COMPATIBILITY_V8.load();
+    private boolean sandboxed = true;
 
     private final Classpath classpath;
 
@@ -200,4 +201,11 @@ public class Config {
         return this.argv;
     }
 
+    public boolean isSandboxed() {
+        return sandboxed;
+    }
+
+    public void setSandboxed(boolean sandboxed) {
+        this.sandboxed = sandboxed;
+    }
 }

--- a/src/main/java/org/dynjs/Config.java
+++ b/src/main/java/org/dynjs/Config.java
@@ -41,7 +41,7 @@ public class Config {
     private boolean jitEnabled = Options.JIT.load();
     private boolean jitAsync = Options.JIT_ASYNC.load();
     private boolean v8Compatible = Options.COMPATIBILITY_V8.load();
-    private boolean sandboxed = true;
+    private boolean sandboxed = false;
 
     private final Classpath classpath;
 

--- a/src/main/java/org/dynjs/Config.java
+++ b/src/main/java/org/dynjs/Config.java
@@ -41,7 +41,7 @@ public class Config {
     private boolean jitEnabled = Options.JIT.load();
     private boolean jitAsync = Options.JIT_ASYNC.load();
     private boolean v8Compatible = Options.COMPATIBILITY_V8.load();
-    private boolean sandboxed = false;
+    private boolean sandbox = false;
 
     private final Classpath classpath;
 
@@ -201,11 +201,11 @@ public class Config {
         return this.argv;
     }
 
-    public boolean isSandboxed() {
-        return sandboxed;
+    public boolean isSandbox() {
+        return sandbox;
     }
 
-    public void setSandboxed(boolean sandboxed) {
-        this.sandboxed = sandboxed;
+    public void setSandbox(boolean sandbox) {
+        this.sandbox = sandbox;
     }
 }

--- a/src/main/java/org/dynjs/parser/ast/BlockStatement.java
+++ b/src/main/java/org/dynjs/parser/ast/BlockStatement.java
@@ -136,6 +136,7 @@ public class BlockStatement extends AbstractStatement {
 
     @Override
     public Completion interpret(ExecutionContext context) {
+        context.checkResourceUsage();
         List<Statement> content = getBlockContent();
 
         Object completionValue = Types.UNDEFINED;

--- a/src/main/java/org/dynjs/runtime/DynJS.java
+++ b/src/main/java/org/dynjs/runtime/DynJS.java
@@ -46,7 +46,7 @@ public class DynJS {
 
     private void loadKernel() {
         // FIXME only works for non-IR atm
-        if (!Config.CompileMode.IR.equals(this.config.getCompileMode())) {
+        if (!Config.CompileMode.IR.equals(this.config.getCompileMode()) && !config.isSandboxed()) {
             switch (this.config.getKernelMode()) {
                 case INTERNAL:
                     // Load pure-JS kernel

--- a/src/main/java/org/dynjs/runtime/DynJS.java
+++ b/src/main/java/org/dynjs/runtime/DynJS.java
@@ -46,7 +46,7 @@ public class DynJS {
 
     private void loadKernel() {
         // FIXME only works for non-IR atm
-        if (!Config.CompileMode.IR.equals(this.config.getCompileMode()) && !config.isSandboxed()) {
+        if (!Config.CompileMode.IR.equals(this.config.getCompileMode()) && !config.isSandbox()) {
             switch (this.config.getKernelMode()) {
                 case INTERNAL:
                     // Load pure-JS kernel

--- a/src/main/java/org/dynjs/runtime/ExceededResourcesException.java
+++ b/src/main/java/org/dynjs/runtime/ExceededResourcesException.java
@@ -1,0 +1,9 @@
+package org.dynjs.runtime;
+
+import org.dynjs.exception.DynJSException;
+
+public class ExceededResourcesException extends DynJSException {
+    public ExceededResourcesException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/dynjs/runtime/GlobalContext.java
+++ b/src/main/java/org/dynjs/runtime/GlobalContext.java
@@ -68,11 +68,11 @@ public class GlobalContext {
         registerBuiltinType("URIError", new BuiltinURIError(this));
         registerBuiltinType("EvalError", new BuiltinEvalError(this));
 
-        if (this.runtime.getConfig().isRhinoCompatible()) {
+        if (this.runtime.getConfig().isRhinoCompatible() && !this.runtime.getConfig().isSandboxed()) {
             registerBuiltinType("JSAdapter", new JSAdapter(this));
         }
 
-        if(this.runtime.getConfig().isV8Compatible()) {
+        if(this.runtime.getConfig().isV8Compatible() && !this.runtime.getConfig().isSandboxed()) {
             defineNonEnumerableProperty(this, "__v8StackGetter", new V8StackGetter(this));
         }
 
@@ -103,7 +103,10 @@ public class GlobalContext {
         defineGlobalProperty("escape", new Escape(this), true);
         defineGlobalProperty("unescape", new Unescape(this), true);
         defineGlobalProperty("print", new Print(this), true);
-        defineGlobalProperty("dynjs", new DynJSBuiltin(this.runtime), true);
+
+        if (!runtime.getConfig().isSandboxed()) {
+            defineGlobalProperty("dynjs", new DynJSBuiltin(this.runtime), true);
+        }
 
         // ----------------------------------------
         // Built-in global objects
@@ -117,15 +120,16 @@ public class GlobalContext {
         // Java integration
         // ----------------------------------------
 
-        defineGlobalProperty("Packages", new JavaPackage(this, null), true );
-        defineGlobalProperty("java",     new JavaPackage(this, "java"), true);
-        defineGlobalProperty("javax",    new JavaPackage(this, "javax"), true);
-        defineGlobalProperty("org",      new JavaPackage(this, "org"), true);
-        defineGlobalProperty("com",      new JavaPackage(this, "com"), true);
-        defineGlobalProperty("io",       new JavaPackage(this, "io"), true);
+        if (!runtime.getConfig().isSandboxed()) {
+            defineGlobalProperty("Packages", new JavaPackage(this, null), true);
+            defineGlobalProperty("java", new JavaPackage(this, "java"), true);
+            defineGlobalProperty("javax", new JavaPackage(this, "javax"), true);
+            defineGlobalProperty("org", new JavaPackage(this, "org"), true);
+            defineGlobalProperty("com", new JavaPackage(this, "com"), true);
+            defineGlobalProperty("io", new JavaPackage(this, "io"), true);
 
-        defineGlobalProperty("System",   System.class, true);
-
+            defineGlobalProperty("System", System.class, true);
+        }
     }
 
     private void registerBuiltinType(String name, final AbstractBuiltinType type) {

--- a/src/main/java/org/dynjs/runtime/GlobalContext.java
+++ b/src/main/java/org/dynjs/runtime/GlobalContext.java
@@ -68,11 +68,11 @@ public class GlobalContext {
         registerBuiltinType("URIError", new BuiltinURIError(this));
         registerBuiltinType("EvalError", new BuiltinEvalError(this));
 
-        if (this.runtime.getConfig().isRhinoCompatible() && !this.runtime.getConfig().isSandboxed()) {
+        if (this.runtime.getConfig().isRhinoCompatible() && !this.runtime.getConfig().isSandbox()) {
             registerBuiltinType("JSAdapter", new JSAdapter(this));
         }
 
-        if(this.runtime.getConfig().isV8Compatible() && !this.runtime.getConfig().isSandboxed()) {
+        if(this.runtime.getConfig().isV8Compatible() && !this.runtime.getConfig().isSandbox()) {
             defineNonEnumerableProperty(this, "__v8StackGetter", new V8StackGetter(this));
         }
 
@@ -104,7 +104,7 @@ public class GlobalContext {
         defineGlobalProperty("unescape", new Unescape(this), true);
         defineGlobalProperty("print", new Print(this), true);
 
-        if (!runtime.getConfig().isSandboxed()) {
+        if (!runtime.getConfig().isSandbox()) {
             defineGlobalProperty("dynjs", new DynJSBuiltin(this.runtime), true);
         }
 
@@ -120,7 +120,7 @@ public class GlobalContext {
         // Java integration
         // ----------------------------------------
 
-        if (!runtime.getConfig().isSandboxed()) {
+        if (!runtime.getConfig().isSandbox()) {
             defineGlobalProperty("Packages", new JavaPackage(this, null), true);
             defineGlobalProperty("java", new JavaPackage(this, "java"), true);
             defineGlobalProperty("javax", new JavaPackage(this, "javax"), true);

--- a/src/main/java/org/dynjs/runtime/ResourceQuota.java
+++ b/src/main/java/org/dynjs/runtime/ResourceQuota.java
@@ -10,7 +10,7 @@ public class ResourceQuota {
     private long memoryUsage;
     private final boolean monitorMemoryUsage;
 
-    ResourceQuota(long cpuTime, long memoryUsage) {
+    public ResourceQuota(long cpuTime, long memoryUsage) {
         this.cpuTime = cpuTime;
         this.monitorCpuTime = cpuTime > 0;
         this.memoryUsage = memoryUsage;

--- a/src/main/java/org/dynjs/runtime/ResourceQuota.java
+++ b/src/main/java/org/dynjs/runtime/ResourceQuota.java
@@ -1,0 +1,68 @@
+package org.dynjs.runtime;
+
+import com.sun.management.ThreadMXBean;
+
+import java.lang.management.ManagementFactory;
+
+public class ResourceQuota {
+    private long cpuTime;
+    private final boolean monitorCpuTime;
+    private long memoryUsage;
+    private final boolean monitorMemoryUsage;
+
+    ResourceQuota(long cpuTime, long memoryUsage) {
+        this.cpuTime = cpuTime;
+        this.monitorCpuTime = cpuTime > 0;
+        this.memoryUsage = memoryUsage;
+        this.monitorMemoryUsage = memoryUsage > 0;
+    }
+
+    public WatchDog createWatchDog() {
+        return new WatchDog();
+    }
+
+    public class WatchDog {
+        private long lastCpuTime = readCpuTime();
+        private long lastAllocatedBytes = readAllocatedBytes();
+
+        public void check() {
+            if (monitorCpuTime) {
+                checkCpuTime();
+            }
+
+            if (monitorMemoryUsage) {
+                checkAllocatedBytes();
+            }
+        }
+
+        private void checkCpuTime() {
+            long current = readCpuTime();
+            long delta = current - lastCpuTime;
+            cpuTime -= delta;
+            lastCpuTime = current;
+
+            if (cpuTime < 0) {
+                throw new ExceededResourcesException("CPU usage has exceeded the allowed quota");
+            }
+        }
+
+        private void checkAllocatedBytes() {
+            long current = readAllocatedBytes();
+            long delta = current - lastAllocatedBytes;
+            memoryUsage -= delta;
+            lastAllocatedBytes = current;
+
+            if (memoryUsage < 0) {
+                throw new ExceededResourcesException("Memory usage has exceeded the allowed quota");
+            }
+        }
+    }
+
+    private static long readCpuTime() {
+        return ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime();
+    }
+
+    private static long readAllocatedBytes() {
+        return ((ThreadMXBean) ManagementFactory.getThreadMXBean()).getThreadAllocatedBytes(Thread.currentThread().getId());
+    }
+}

--- a/src/main/java/org/dynjs/runtime/ResourceQuota.java
+++ b/src/main/java/org/dynjs/runtime/ResourceQuota.java
@@ -1,31 +1,53 @@
 package org.dynjs.runtime;
 
-import com.sun.management.ThreadMXBean;
-
 import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ResourceQuota {
-    private long cpuTime;
+    // Sadly, the call needed to monitor memory allocations made by a thread is specific to
+    // Oracle's implementation. Under other JVMs we won't be able to enforce memory quotas.
+    private static final ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
+    private static final ThreadMXBean sunThreadMxBean = threadMxBean instanceof com.sun.management.ThreadMXBean ? (com.sun.management.ThreadMXBean) threadMxBean : null;
+
+    private AtomicLong cpuTime;
+    private AtomicLong memoryUsage;
     private final boolean monitorCpuTime;
-    private long memoryUsage;
     private final boolean monitorMemoryUsage;
 
     public ResourceQuota(long cpuTime, long memoryUsage) {
-        this.cpuTime = cpuTime;
-        this.monitorCpuTime = cpuTime > 0;
-        this.memoryUsage = memoryUsage;
-        this.monitorMemoryUsage = memoryUsage > 0;
+        this.cpuTime = new AtomicLong(cpuTime);
+        this.memoryUsage = new AtomicLong(memoryUsage);
+
+        monitorCpuTime = cpuTime > 0;
+        monitorMemoryUsage = memoryUsage > 0;
+        if (monitorMemoryUsage && sunThreadMxBean == null) {
+            throw new UnsupportedOperationException("Cannot enforce memory quotas when not using Oracle's JVM implementation");
+        }
     }
 
+    // WatchDogs decrement the quota values every time they are checked. Once the
+    // values reach 0 an exception is thrown. By decoupling this task from the Quota
+    // it is possible to use the same quota for several script invocations.
     public WatchDog createWatchDog() {
         return new WatchDog();
     }
 
     public class WatchDog {
-        private long lastCpuTime = readCpuTime();
-        private long lastAllocatedBytes = readAllocatedBytes();
+        private static final int CHECK_EVERY = 25;
+
+        private long threadId = Thread.currentThread().getId();
+        private long lastCpuTime = readCpuTime(threadId);
+        private long lastAllocatedBytes = readAllocatedBytes(threadId);
+        private int cycle = 0;
 
         public void check() {
+            assert(Thread.currentThread().getId() == threadId);
+
+            if (++cycle % CHECK_EVERY != 0) {
+                return;
+            }
+
             if (monitorCpuTime) {
                 checkCpuTime();
             }
@@ -36,33 +58,31 @@ public class ResourceQuota {
         }
 
         private void checkCpuTime() {
-            long current = readCpuTime();
+            long current = readCpuTime(threadId);
             long delta = current - lastCpuTime;
-            cpuTime -= delta;
             lastCpuTime = current;
 
-            if (cpuTime < 0) {
+            if (cpuTime.addAndGet(-delta) < 0) {
                 throw new ExceededResourcesException("CPU usage has exceeded the allowed quota");
             }
         }
 
         private void checkAllocatedBytes() {
-            long current = readAllocatedBytes();
+            long current = readAllocatedBytes(threadId);
             long delta = current - lastAllocatedBytes;
-            memoryUsage -= delta;
             lastAllocatedBytes = current;
 
-            if (memoryUsage < 0) {
+            if (memoryUsage.addAndGet(-delta) < 0) {
                 throw new ExceededResourcesException("Memory usage has exceeded the allowed quota");
             }
         }
     }
 
-    private static long readCpuTime() {
-        return ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime();
+    private static long readCpuTime(long threadId) {
+        return threadMxBean.getThreadCpuTime(threadId);
     }
 
-    private static long readAllocatedBytes() {
-        return ((ThreadMXBean) ManagementFactory.getThreadMXBean()).getThreadAllocatedBytes(Thread.currentThread().getId());
+    private static long readAllocatedBytes(long threadId) {
+        return ((com.sun.management.ThreadMXBean) threadMxBean).getThreadAllocatedBytes(threadId);
     }
 }

--- a/src/test/java/org/dynjs/runtime/ResourceQuotaTest.java
+++ b/src/test/java/org/dynjs/runtime/ResourceQuotaTest.java
@@ -70,11 +70,18 @@ public class ResourceQuotaTest extends AbstractDynJSTestSupport {
     @Test(expected = ExceededResourcesException.class)
     public void theSameQuotaCanBeUsedSuccessively() {
         DynJS runtime = getRuntime();
-        ResourceQuota quota = new ResourceQuota(0, 1000000000);
+        ResourceQuota quota = new ResourceQuota(1000000000L, 0);
 
-        for (int i = 0; i < 1000000; ++i) {
-            ExecutionContext context = runtime.getDefaultExecutionContext().createResourceQuotaExecutionObject(quota);
-            runtime.newRunner().withContext(context).withSource("var str = 'foo' + 'bar';").evaluate();
+        int count = 0;
+        try {
+            for (int i = 0; i < 1000000; ++i) {
+                ExecutionContext context = runtime.getDefaultExecutionContext().createResourceQuotaExecutionObject(quota);
+                runtime.newRunner().withContext(context).withSource("for (var i = 0; i < 1000; ++i) {}").evaluate();
+                ++count;
+            }
+        } catch (ExceededResourcesException ex) {
+            Assert.assertTrue(count > 0);
+            throw ex;
         }
     }
 

--- a/src/test/java/org/dynjs/runtime/ResourceQuotaTest.java
+++ b/src/test/java/org/dynjs/runtime/ResourceQuotaTest.java
@@ -1,0 +1,111 @@
+package org.dynjs.runtime;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResourceQuotaTest extends AbstractDynJSTestSupport {
+    @Test
+    public void testCpuTimeCannotExceedQuota() {
+        shouldExceedCpuQuota("for (;;) {}");
+    }
+
+    @Test
+    public void testReasonableCpuUsageDoesntExceedQuota() {
+        shouldNotExceedCpuQuota("for (var i = 0; i < 1000; ++i) { var j = i + 10; }");
+    }
+
+    @Test
+    public void settingPropertiesOnObjectsCannotExceedMemoryQuota() {
+        shouldExceedMemoryQuota("var obj = {}; for (var i = 0;; ++i) { obj[i.toString()] = 'foo'; }");
+    }
+
+    @Test
+    public void settingTheSameNamedPropertyOverAndOverAgainDoesntExceedQuota() {
+        shouldNotExceedMemoryQuota("var obj = {}; for (var i = 0; i < 100000; ++i) { obj['foo'] = i; }");
+    }
+
+    @Test
+    public void settingTheSameIndexedPropertyOverAndOverAgainDoesntExceedQuota() {
+        shouldNotExceedMemoryQuota("var obj = {}; for (var i = 0; i < 100000; ++i) { obj[10] = i; }");
+    }
+
+    @Test
+    public void settingValuesInArrayCannotExceedMemoryQuota() {
+        shouldExceedMemoryQuota("var obj = []; for (var i = 0;; ++i) { obj[i] = 'foo'; }");
+    }
+
+    @Test
+    public void growingArrayWithPushCannotExceedMemoryQuota() {
+        shouldExceedMemoryQuota("var obj = []; for (var i = 0;; ++i) { obj.push.apply(obj, obj); }");
+    }
+
+    @Test
+    public void growingArrayWithConcatCannotExceedMemoryQuota() {
+        shouldExceedMemoryQuota("var obj = []; for (var i = 0;; ++i) { obj.concat(obj); }");
+    }
+
+    @Test
+    public void buildingLargeStringWithPlusOperatorCannotExceedMemoryQuota() {
+        shouldExceedMemoryQuota("var str = ''; for (;;) { str = str + 'foo'; }");
+    }
+
+    @Test
+    public void buildingLargeStringWithPlusEqualOperatorCannotExceedMemoryQuota() {
+        shouldExceedMemoryQuota("var str = ''; for (;;) { str += 'foo'; }");
+    }
+
+    @Test
+    public void buildingLargeStringWithConcatCannotExceedMemoryQuota() {
+        shouldExceedMemoryQuota("var str = ''; for (;;) { str = str.concat(str); }");
+    }
+
+    private void shouldExceedCpuQuota(String lines) {
+        ResourceQuota quota = new ResourceQuota(1000000000L, 0);
+        DynJS runtime = getRuntime();
+        ExecutionContext context = runtime.getDefaultExecutionContext().createResourceQuotaExecutionObject(quota);
+
+        try {
+            runtime.newRunner().withContext(context).withSource(lines).evaluate();
+            Assert.assertTrue("CPU quota should have been exceeded", false);
+        } catch (ExceededResourcesException ex) {
+            // OK
+        }
+    }
+
+    private void shouldNotExceedCpuQuota(String lines) {
+        ResourceQuota quota = new ResourceQuota(1000000000L, 0);
+        DynJS runtime = getRuntime();
+        ExecutionContext context = runtime.getDefaultExecutionContext().createResourceQuotaExecutionObject(quota);
+
+        try {
+            runtime.newRunner().withContext(context).withSource(lines).evaluate();
+        } catch (ExceededResourcesException ex) {
+            Assert.assertTrue("CPU quota shouldn't have been exceeded", false);
+        }
+    }
+
+    private void shouldExceedMemoryQuota(String lines) {
+        DynJS runtime = getRuntime();
+        ResourceQuota quota = new ResourceQuota(0, 1000000000);
+        ExecutionContext context = runtime.getDefaultExecutionContext().createResourceQuotaExecutionObject(quota);
+
+        try {
+            runtime.newRunner().withContext(context).withSource(lines).evaluate();
+            Assert.assertTrue("Memory quota should have been exceeded", false);
+        } catch (ExceededResourcesException ex) {
+            // OK
+        }
+    }
+
+    private void shouldNotExceedMemoryQuota(String lines) {
+        DynJS runtime = getRuntime();
+        ResourceQuota quota = new ResourceQuota(0, 1000000000);
+        ExecutionContext context = runtime.getDefaultExecutionContext().createResourceQuotaExecutionObject(quota);
+
+        try {
+            runtime.newRunner().withContext(context).withSource(lines).evaluate();
+        } catch (ExceededResourcesException ex) {
+            Assert.assertTrue("Memory quota shouldn't have been exceeded", false);
+        }
+    }
+}

--- a/src/test/java/org/dynjs/runtime/ResourceQuotaTest.java
+++ b/src/test/java/org/dynjs/runtime/ResourceQuotaTest.java
@@ -16,48 +16,48 @@ public class ResourceQuotaTest extends AbstractDynJSTestSupport {
     }
 
     @Test
-    public void settingPropertiesOnObjectsCannotExceedMemoryQuota() {
+    public void settingPropertiesOnObjectsExceedsMemoryQuota() {
         shouldExceedMemoryQuota("var obj = {}; for (var i = 0;; ++i) { obj[i.toString()] = 'foo'; }");
     }
 
     @Test
-    public void settingTheSameNamedPropertyOverAndOverAgainDoesntExceedQuota() {
-        shouldNotExceedMemoryQuota("var obj = {}; for (var i = 0; i < 100000; ++i) { obj['foo'] = i; }");
-    }
-
-    @Test
-    public void settingTheSameIndexedPropertyOverAndOverAgainDoesntExceedQuota() {
-        shouldNotExceedMemoryQuota("var obj = {}; for (var i = 0; i < 100000; ++i) { obj[10] = i; }");
-    }
-
-    @Test
-    public void settingValuesInArrayCannotExceedMemoryQuota() {
+    public void settingValuesInArrayExceedsMemoryQuota() {
         shouldExceedMemoryQuota("var obj = []; for (var i = 0;; ++i) { obj[i] = 'foo'; }");
     }
 
     @Test
-    public void growingArrayWithPushCannotExceedMemoryQuota() {
+    public void growingArrayWithPushExceedsMemoryQuota() {
         shouldExceedMemoryQuota("var obj = []; for (var i = 0;; ++i) { obj.push.apply(obj, obj); }");
     }
 
     @Test
-    public void growingArrayWithConcatCannotExceedMemoryQuota() {
+    public void growingArrayWithConcatExceedsMemoryQuota() {
         shouldExceedMemoryQuota("var obj = []; for (var i = 0;; ++i) { obj.concat(obj); }");
     }
 
     @Test
-    public void buildingLargeStringWithPlusOperatorCannotExceedMemoryQuota() {
+    public void buildingLargeStringWithPlusOperatorExceedsMemoryQuota() {
         shouldExceedMemoryQuota("var str = ''; for (;;) { str = str + 'foo'; }");
     }
 
     @Test
-    public void buildingLargeStringWithPlusEqualOperatorCannotExceedMemoryQuota() {
+    public void buildingLargeStringWithPlusEqualOperatorExceedsMemoryQuota() {
         shouldExceedMemoryQuota("var str = ''; for (;;) { str += 'foo'; }");
     }
 
     @Test
-    public void buildingLargeStringWithConcatCannotExceedMemoryQuota() {
+    public void buildingLargeStringWithConcatExceedsMemoryQuota() {
         shouldExceedMemoryQuota("var str = ''; for (;;) { str = str.concat(str); }");
+    }
+
+    @Test
+    public void settingTheSameNamedPropertyOverAndOverAgainDoesntTriggerQuota() {
+        shouldNotExceedMemoryQuota("var obj = {}; for (var i = 0; i < 100000; ++i) { obj['foo'] = i; }");
+    }
+
+    @Test
+    public void settingTheSameIndexedPropertyOverAndOverAgainDoesntTriggerQuota() {
+        shouldNotExceedMemoryQuota("var obj = {}; for (var i = 0; i < 100000; ++i) { obj[10] = i; }");
     }
 
     @Test
@@ -86,7 +86,7 @@ public class ResourceQuotaTest extends AbstractDynJSTestSupport {
     }
 
     @Test
-    @Ignore
+    @Ignore // only useful when run manually
     public void performanceComparisonWhenRunningWithOrWithoutQuotaIsntTooBad() {
         DynJS runtime = getRuntime();
 

--- a/src/test/java/org/dynjs/runtime/SandboxTest.java
+++ b/src/test/java/org/dynjs/runtime/SandboxTest.java
@@ -7,17 +7,17 @@ import org.junit.Test;
 public class SandboxTest extends AbstractDynJSTestSupport {
     @Test(expected = ThrowException.class)
     public void jsCodeCannotAccessDynJSGlobalWhenRunningInSandbox() {
-        eval("dynjs");
+        eval("var foo = dynjs;");
     }
 
     @Test(expected = ThrowException.class)
     public void jsCodeCannotAccessJavaPackageWhenRunningInSandbox() {
-        eval("java");
+        eval("var foo = java;");
     }
 
     @Test(expected = ThrowException.class)
     public void jsCodeCannotAccessOrgPackageWhenRunningInSandbox() {
-        eval("org");
+        eval("var foo = org;");
     }
 
     @Override

--- a/src/test/java/org/dynjs/runtime/SandboxTest.java
+++ b/src/test/java/org/dynjs/runtime/SandboxTest.java
@@ -1,0 +1,29 @@
+package org.dynjs.runtime;
+
+import org.dynjs.Config;
+import org.dynjs.exception.ThrowException;
+import org.junit.Test;
+
+public class SandboxTest extends AbstractDynJSTestSupport {
+    @Test(expected = ThrowException.class)
+    public void jsCodeCannotAccessDynJSGlobalWhenSandboxed() {
+        eval("dynjs");
+    }
+
+    @Test(expected = ThrowException.class)
+    public void jsCodeCannotAccessJavaPackageWhenSandboxed() {
+        eval("java");
+    }
+
+    @Test(expected = ThrowException.class)
+    public void jsCodeCannotAccessOrgPackageWhenSandboxed() {
+        eval("org");
+    }
+
+    @Override
+    protected org.dynjs.Config createConfig() {
+        Config config = super.createConfig();
+        config.setSandboxed(true);
+        return config;
+    }
+}

--- a/src/test/java/org/dynjs/runtime/SandboxTest.java
+++ b/src/test/java/org/dynjs/runtime/SandboxTest.java
@@ -6,24 +6,24 @@ import org.junit.Test;
 
 public class SandboxTest extends AbstractDynJSTestSupport {
     @Test(expected = ThrowException.class)
-    public void jsCodeCannotAccessDynJSGlobalWhenSandboxed() {
+    public void jsCodeCannotAccessDynJSGlobalWhenRunningInSandbox() {
         eval("dynjs");
     }
 
     @Test(expected = ThrowException.class)
-    public void jsCodeCannotAccessJavaPackageWhenSandboxed() {
+    public void jsCodeCannotAccessJavaPackageWhenRunningInSandbox() {
         eval("java");
     }
 
     @Test(expected = ThrowException.class)
-    public void jsCodeCannotAccessOrgPackageWhenSandboxed() {
+    public void jsCodeCannotAccessOrgPackageWhenRunningInSandbox() {
         eval("org");
     }
 
     @Override
     protected org.dynjs.Config createConfig() {
         Config config = super.createConfig();
-        config.setSandboxed(true);
+        config.setSandbox(true);
         return config;
     }
 }


### PR DESCRIPTION
This is a feature I've developed for our own usage, but since it might be useful for others I'm submitting it here. I'll let you choose whether this deserves being merged here or not.

The goal is to allow more secure embedding of DynJS by:

1) Preventing JS code from accessing outside APIs (e.g. Java libraries)
2) Enforcing CPU and memory quotas when JS code is being executed

The first one boils down to an additional config option that prevents Java packages from being exposed to JS code.

The second one is slightly more complex. It uses performance counters to monitor the CPU usage and total allocations for the thread while JS code is running. At regular interval the quotas are checked, and if they are found to be exceeded an exception is thrown.

Sadly, those counters are only available on Hotspot, so attempting to use resource quotas on JVMs that don't implement them will result in an exception being thrown.

I haven't yet battle tested the "strength" of this sandbox, but as of now I know of no way to circumvent it.
